### PR TITLE
chore(deps): suppress Dependabot alerts for cdktf-bundled deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Dependabot configuration
+#
+# This file primarily exists to suppress Dependabot security alerts for
+# packages that are bundled inside `cdktf` via `bundledDependencies`, which
+# cannot be overridden from this repository's `package.json` `overrides`
+# field. The vulnerabilities only affect dev-time tooling used to synthesize
+# Terraform HCL (`deployment/gcp` is a private CDKTF workspace and never ships
+# to production), so the residual risk is tolerable.
+#
+# Re-evaluate this configuration when `cdktf` upgrades its bundled `archiver`
+# tree upstream (currently cdktf@0.21.0 bundles archiver@7.0.1 with vulnerable
+# lodash / minimatch / glob / brace-expansion versions).
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/deployment/gcp"
+    schedule:
+      interval: "weekly"
+    # Disable version-update PRs; security-update PRs are still emitted
+    # automatically for non-ignored packages.
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "archiver"
+      - dependency-name: "lodash"
+      - dependency-name: "minimatch"
+      - dependency-name: "glob"
+      - dependency-name: "brace-expansion"


### PR DESCRIPTION
## Summary
- `deployment/gcp` の 12 件の Dependabot security alerts はすべて `cdktf@0.21.0` の `bundledDependencies` (`archiver@7.0.1`) に同梱された脆弱な `lodash` / `minimatch` / `glob` / `brace-expansion` 由来。
- `bundledDependencies` は npm `overrides` で到達できないため、本リポジトリ側からは解消不能（上流 cdktf の更新待ち）。
- `deployment/gcp` は CDKTF synth 用の private workspace（本番 runtime に同梱されない dev-time tooling）であり、各脆弱性の attack surface（信頼できないテンプレ文字列・glob パターン入力）が現実的に成立しないため、残留リスクは tolerable と判断。

## 変更点
- `.github/dependabot.yml` を新規作成し、`deployment/gcp` 配下の `archiver` / `lodash` / `minimatch` / `glob` / `brace-expansion` を `ignore` に登録。
- `open-pull-requests-limit: 0` で version-update PR を抑制（security-update PR は ignore 外のパッケージに対して引き続き動作）。

## 対象アラート (dismiss 予定)
| # | Severity | Package | CVE |
|---|---|---|---|
| 182 | high | lodash | CVE-2026-4800 |
| 181 | medium | lodash | CVE-2026-2950 |
| 92 | medium | lodash | CVE-2025-13465 |
| 121 | high | minimatch | CVE-2026-27904 |
| 120 | high | minimatch | CVE-2026-27903 |
| 119 | high | minimatch | CVE-2026-27903 |
| 117 | high | minimatch | CVE-2026-27904 |
| 111 | high | minimatch | CVE-2026-26996 |
| 110 | high | minimatch | CVE-2026-26996 |
| 79 | high | glob | CVE-2025-64756 |
| 171 | medium | brace-expansion | CVE-2026-33750 |
| 64 | low | brace-expansion | CVE-2025-5889 |

## Test plan
- [ ] CI が緑であること
- [ ] マージ後、Dependabot UI で 12 件が dismissed (tolerable_risk) になっていること
- [ ] `deployment/gcp` 以外の ecosystem (frontend, backend) の Dependabot 動作に影響していないこと

## Follow-up
- cdktf が archiver を更新したタイミングで `.github/dependabot.yml` の `ignore` 設定を見直す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)