### PR TITLE
chore: ignore .claude/ local state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# Claude Code local state
+.claude/
+
 # yarn v2
 .yarn/cache
 .yarn/unplugged


### PR DESCRIPTION
## Summary
- Claude Code がローカルに作成する `.claude/` ディレクトリを `.gitignore` に追加。

## Test plan
- [ ] `git status` で `.claude/` が untracked として表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)